### PR TITLE
Drop secrets for now

### DIFF
--- a/.github/chainguard/mattmoor.sts.yaml
+++ b/.github/chainguard/mattmoor.sts.yaml
@@ -10,6 +10,6 @@ claim_pattern:
 permissions:
   metadata: read
   administration: read # To list deploy keys
-  secrets: read # To enumerate secret metadata (no values)
+  # secrets: read # To enumerate secret metadata (no values)
 
 repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
Turns out we haven't granted this on the installation yet, but we'll want this to audit secret age for rotation (eventually) :-/