### PR TITLE
Grant permission to read org rulesets

### DIFF
--- a/.github/chainguard/mattmoor.sts.yaml
+++ b/.github/chainguard/mattmoor.sts.yaml
@@ -10,6 +10,7 @@ claim_pattern:
 permissions:
   metadata: read
   administration: read # To list deploy keys
+  organization_administration: read # To read organization rulesets
   # secrets: read # To enumerate secret metadata (no values)
 
 repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
The documentation lists `:write` but that can't be right for simple enumeration: https://docs.github.com/en/rest/orgs/rules?apiVersion=2022-11-28#get-an-organization-repository-ruleset