### PR TITLE
Update chown command on Dockerfile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -56,7 +56,7 @@ FROM cgr.dev/chainguard/wolfi-base
 ARG version=3.11
 WORKDIR /app
 
-RUN apk add python-${version} && chown -R nonroot.nonroot /app/
+RUN apk add python-${version} && chown -R nonroot:nonroot /app/
 
 USER nonroot
 


### PR DESCRIPTION
Busybox's version 1.37 `chown` deprecated using USER.GROUP and is now enforcing the USER:GROUP format.