### PR TITLE
add oct-sts policy for project board syncer

### DIFF
--- a/.github/chainguard/project-board-sync.sts.yaml
+++ b/.github/chainguard/project-board-sync.sts.yaml
@@ -2,15 +2,15 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:chainguard-dev/project-backup:ref:refs/heads/main
 claim_pattern:
   # Restrict to specific workflow
-  workflow_ref: chainguard-dev/project-backup/.github/workflows/sync-pr-board\.yml@refs/heads/main
+  workflow_ref: chainguard-dev/project-backup/.github/workflows/sync-pr-board-wolfi.yml@refs/heads/main
 
 permissions:
   metadata: read
   contents: read
-  issues: read
+  issues: write
   pull_requests: read
   repository_projects: read
-  organization_projects: read
+  organization_projects: write
   members: read
 
 repositories:

--- a/.github/chainguard/project-board-sync.sts.yaml
+++ b/.github/chainguard/project-board-sync.sts.yaml
@@ -1,0 +1,18 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/project-backup:ref:refs/heads/main
+claim_pattern:
+  # Restrict to specific workflow
+  workflow_ref: chainguard-dev/project-backup/.github/workflows/sync-pr-board\.yml@refs/heads/main
+
+permissions:
+  metadata: read
+  contents: read
+  issues: read
+  pull_requests: read
+  repository_projects: read
+  organization_projects: read
+  members: read
+
+repositories:
+  - wolfi-dev/os
+  - wolfi-dev/advisories


### PR DESCRIPTION
This is to replace PAT token https://github.com/chainguard-dev/project-backup/blob/40cb18de571d43ca59b774ee36ded3137413307d/.github/workflows/sync-pr-board.yml#L38