### PR TITLE
fix: add organization_administration write to verify and sync policies

### DIFF
--- a/.github/chainguard/sync-github.sts.yaml
+++ b/.github/chainguard/sync-github.sts.yaml
@@ -7,6 +7,7 @@ claim_pattern:
   job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
 
 permissions:
+  organization_administration: write # required to manage organization rulesets
   administration: write # required to manage the repository
   contents: write # required per terraform docs (https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository)
   members: write # to add/remove GitHub members

--- a/.github/chainguard/verify-github.sts.yaml
+++ b/.github/chainguard/verify-github.sts.yaml
@@ -7,6 +7,7 @@ claim_pattern:
   job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
 
 permissions:
+  organization_administration: write # required to read organization rulesets
   administration: read # required to read the repository
   contents: write # required per terraform docs (https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository)
   members: read # to add/remove GitHub members


### PR DESCRIPTION
## Summary

Add `organization_administration: write` to both verify-github and sync-github STS policies. Required for terraform to read and manage organization rulesets.