### PR TITLE
Add Octo STS policy for livegrep.chaindag.dev indexer

### DIFF
--- a/.github/chainguard/chaindag-livegrep-indexer.sts.yaml
+++ b/.github/chainguard/chaindag-livegrep-indexer.sts.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the livegrep.chaindag.dev indexer.
+# Service account: livegrep@chaindag.iam.gserviceaccount.com
+# Deployed by: env/chaindag.dev/iac/livegrep.tf in chainguard-dev/mono
+
+issuer: https://accounts.google.com
+subject: "106681300217655979572"
+
+permissions:
+  # Clone repository contents for code search indexing
+  contents: read
+  # Required baseline permission for all GitHub API access
+  metadata: read


### PR DESCRIPTION
## What

Add the Octo STS policy that lets the `livegrep.chaindag.dev` indexer mint a read-only GitHub token for this org.

## Why

We are expanding livegrep beyond `chainguard-dev` to cover every org in the Chainguard enterprise account. The indexer authenticates per-org via Octo STS, so each org needs its own policy granting the indexer GCP service account `contents: read` + `metadata: read`.

## Notes

- Subject is the unique ID of `livegrep@chaindag.iam.gserviceaccount.com`.
- The same policy is already deployed in `chainguard-dev/.github`.
- The indexer is defined in `env/chaindag.dev/iac/livegrep.tf` in `chainguard-dev/mono`; expanding `indexer_orgs` to include this org is a follow-up there.